### PR TITLE
Fix api.json format doc

### DIFF
--- a/app/app/views/doc/apiJson.scala.html
+++ b/app/app/views/doc/apiJson.scala.html
@@ -131,13 +131,12 @@
 
   <pre>
     {
-      "name": {
+      "name": <em>string</em>,
       "description": <em>string (optional)</em>,
       "plural": <em>string (optional)</em>,
       "fields": <em>JSON Array of <a href="#field">Field</a></em> (optional)</em>,
       "attributes": <em>JSON Array of <a href="#attribute">Attribute</a> (optional)</em>,
       "deprecation": <em>JSON Object of <a href="#deprecation">Deprecation</a> (optional)</em>
-      }
     }
   </pre>
 


### PR DESCRIPTION
I believe interfaces.name is a string, not an object